### PR TITLE
Keep instructions in one place and make them easier

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mf-install
 Media Foundation workaround for Wine
-Test
+
 Easily add Media Foundation support to a Wine prefix. Just set WINEPREFIX to a valid Wine prefix and run.
 
 Example usage:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mf-install
 Media Foundation workaround for Wine
-
+Test
 Easily add Media Foundation support to a Wine prefix. Just set WINEPREFIX to a valid Wine prefix and run.
 
 Example usage:

--- a/mf-install.sh
+++ b/mf-install.sh
@@ -30,7 +30,7 @@ fi
 set -e
 export WINEDEBUG="-all"
 
-scriptdir=$(dirname "$0")
+scriptdir="$(dirname "$(realpath "$0")")"
 cd "$scriptdir"
 
 cp -v syswow64/* "$WINEPREFIX/drive_c/windows/syswow64"


### PR DESCRIPTION
I saw your exchange with michaldybczak in the issues tab. I tend to lean towards your stance of not bloating the readme. However despite your instructions within the script and me being comparably capable with such things, I made a mistake first try and had to think for half a minute until I realized my mistake. I don't want to sound presumptuous but if I fail to use such a simple to use tool first try many less experienced users will have a hard time.

This is why I propose to you my compromise of giving easy to use instructions without bloating the readme considerably. If someone fails to use the tool with these instructions there is nothing we can do. This is not a tutorial project. But I hope you agree that we should (or at least could without any harm) give this much help for first time users.