### PR TITLE
Indicate compatibility with Not For Broadcast: Prologue

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ For CPUs with more than 8 physical cores see this known issue: https://github.co
 - FINAL FANTASY TYPE-0 HD
 - GRIS
 - Monster Hunter World
+- Not For Broadcast: Prologue
 - Obduction
 - PC Building Simulator
 - Postal 4


### PR DESCRIPTION
Not For Broadcast: Prologue is tested and working with mf-install. Without it, it will otherwise not proceed after the "wait for the signal" dialogue because the video won't play.