### PR TITLE
Document Valfaris as a working game.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ For CPUs with more than 8 physical cores see this known issue: https://github.co
 - Stranded Sails - Explorers of the Cursed Islands
 - Team Sonic Racing
 - The Outer Worlds
+- Valfaris
 - Yaga
 
 And many more


### PR DESCRIPTION
Valfaris is known to be a game that needs Media Foundation:

https://github.com/ValveSoftware/Proton/issues/3208#issuecomment-552440599

I am happily running the GOG version with this.