### PR TITLE
Fully resolve scriptdir path

### DIFF
--- a/mf-install.sh
+++ b/mf-install.sh
@@ -32,7 +32,7 @@ fi
 set -e
 export WINEDEBUG="-all"
 
-scriptdir=$(dirname "$0")
+scriptdir="$(dirname "$(realpath "$0")")"
 cd "$scriptdir"
 
 cp -v syswow64/* "$WINEPREFIX/drive_c/windows/syswow64"


### PR DESCRIPTION
This fixes #68.

If the script is called via a symbolic link, the `scriptdir` variable is currently not populated with the path to the script directory, but resolving the link first fixes it.  The man page for readlink says that realpath is preferred in this situation, so I used that instead.