### PR TITLE
Updated for newer protons with soldier runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ For CPUs with more than 8 physical cores see this known issue: https://github.co
 
 ### Some known working games:
 - American Fugitive
+- Blair Witch VR
 - Blasphemous
 - BlazBlue: Central Fiction
 - Breathedge

--- a/mf-install.sh
+++ b/mf-install.sh
@@ -42,8 +42,17 @@ export WINEDEBUG="-all"
 scriptdir="$(dirname "$(realpath "$0")")"
 cd "$scriptdir"
 
-cp -vf syswow64/* "$WINEPREFIX/drive_c/windows/syswow64"
-cp -vf system32/* "$WINEPREFIX/drive_c/windows/system32"
+for dir in syswow64 system32
+do
+  for file in $dir/*
+  do
+    [[ -L "$WINEPREFIX/drive_c/windows/$dir/$(basename "$file")" ]] && rm "$WINEPREFIX/drive_c/windows/$dir/$(basename "$file")"
+    cp -fv "$file" "$WINEPREFIX/drive_c/windows/$dir/"
+  done
+done
+
+#cp -vf syswow64/* "$WINEPREFIX/drive_c/windows/syswow64"
+#cp -vf system32/* "$WINEPREFIX/drive_c/windows/system32"
 
 override_dll "colorcnv"
 override_dll "mf"


### PR DESCRIPTION
That makes this script work with newer soldier-based protons. It removes the symbolic link and can copy the file without permission errors. It increases the prefix a little (because it skips deduplication) but at least doesn't modify the original proton installation, and when the game is uninstalled the entire prefix is removed with no harm.